### PR TITLE
Fix the shebang line per best practices

### DIFF
--- a/bin/csvgrep
+++ b/bin/csvgrep
@@ -1,4 +1,4 @@
-#!perl
+#!/usr/bin/env perl
 use 5.010;
 use strict;
 use warnings;


### PR DESCRIPTION
The `#!perl` line doesn't work on my Perl (Fedora 25). Best practice is to use `#!/bin/env perl` instead.