### PR TITLE
Set binmode to UTF-8 for output

### DIFF
--- a/bin/csvgrep
+++ b/bin/csvgrep
@@ -7,6 +7,8 @@ use Text::CSV_XS;
 use Text::Table::Tiny qw/ generate_table /;
 use Getopt::Long;
 
+binmode(STDOUT, ":utf8");
+
 my $SHOW_COUNT_THRESHOLD = 7;
 my $usage_string         = "usage: $0 [-h] [-d <dir>] [-i] <pattern> <file>\n";
 my $case_insensitive     = 0;


### PR DESCRIPTION
The CSV files I was processing had some non-ASCII strings which were being mangled in the output. Setting the binmode to UTF-8 solved this problem.