### PR TITLE
Fixes missing POD issue.

### DIFF
--- a/lib/csvgrep.pm
+++ b/lib/csvgrep.pm
@@ -6,23 +6,4 @@ use warnings;
 
 1;
 
-=head1 NAME
-
-csvgrep - search for a pattern in a CSV file and display results in a table
-
-=head1 DESCRIPTION
-
-This is an empty module.
-Look at the csvgrep script that comes in the distribution.
-
-=head1 AUTHOR
-
-Neil Bowers E<lt>neilb@cpan.orgE<gt>
-
-=head1 COPYRIGHT AND LICENSE
-
-This software is copyright (c) 2017 by Neil Bowers <neilb@cpan.org>.
-
-This is free software; you can redistribute it and/or modify it under
-the same terms as the Perl 5 programming language system itself.
 


### PR DESCRIPTION
By removing the (dummy) POD from csvgrep.pm the real POD documentation
in bin/csvgrep will be easier to access at metacpan.org.

See https://github.com/metacpan/metacpan-web/issues/2181 for more information.

The [`csvgrep`](https://metacpan.org/release/NEILB/csvgrep-0.07) distribution contains no modules, but has a single script also called [`csvgrep`](https://st.aticpan.org/source/NEILB/csvgrep-0.07/bin/csvgrep) in the `bin` folder. There is a dummy module [`csvgrep.pm`](https://st.aticpan.org/source/NEILB/csvgrep-0.07/lib/csvgrep.pm) in the `lib` folder. The problem is that this module does not contain the documentation for the script. The real documentation is in the script in the bin folder. When a user searches for `csvgrep` on metacpan.org he will end up with the page with no documentation. 

The user is supposed to find this page:

   https://metacpan.org/pod/release/NEILB/csvgrep-0.07/bin/csvgrep

but it is not so easy to find from the metacpan.org UI.
