### PR TITLE
Remove trailing whitespace in source files

### DIFF
--- a/bin/csvgrep
+++ b/bin/csvgrep
@@ -79,7 +79,7 @@ sub process_command_line
 {
     my $dirpath;
     my $help = 0;
-    
+
     GetOptions(
         'ignore-case|i'     => \$case_insensitive,
         'help|h'            => \$help,


### PR DESCRIPTION
Some projects consider removing trailing whitespace to be a must, and
some see it simply as nit-picking. Either way, I noticed this issue
while reading the source code and thought you might like to use the
change. If you don't see it as necessary, I'm happy with this PR being
closed unmerged.