### PR TITLE
Add strict and warnings pragmas to test file

### DIFF
--- a/t/01-noop.t
+++ b/t/01-noop.t
@@ -1,4 +1,6 @@
 #!perl
+use strict;
+use warnings;
 
 use Test::More 0.88;
 


### PR DESCRIPTION
Using the strict and warnings pragmas is considered modern best
practice.  This issue was found by `Perl::Critic`.

This PR is submitted in the hope that it is useful. If you would like it changed in any way, please just let me know and I'll be happy to update and resubmit as appropriate.