### PR TITLE
Use strict validation of binmode encoding

### DIFF
--- a/bin/csvgrep
+++ b/bin/csvgrep
@@ -7,7 +7,7 @@ use Text::CSV_XS;
 use Text::Table::Tiny qw/ generate_table /;
 use Getopt::Long;
 
-binmode(STDOUT, ":utf8");
+binmode(STDOUT, ":encoding(UTF-8)");
 
 my $SHOW_COUNT_THRESHOLD = 7;
 my $usage_string         = "usage: $0 [-h] [-d <dir>] [-i] <pattern> <file>\n";


### PR DESCRIPTION
`Perl::Critic` recommended this change and even though this is for
output (and is hence supposed to be ok, [according to the Perl::Critic
docs](https://metacpan.org/pod/Perl::Critic::Policy::InputOutput::RequireEncodingWithUTF8Layer),
I thought it would be helpful to include.

If you'd like anything changed in this PR, please just let me know and I'm more than happy to update and resubmit as appropriate.