### PR TITLE
Add initial GitHub workflow for Linux systems

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,30 @@
+name: linux
+
+on: [push, pull_request]
+
+jobs:
+  perl_tester:
+    runs-on: 'ubuntu-latest'
+    name: "perl v${{ matrix.perl-version }}"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        perl-version:
+          - "5.32"
+          - "5.30"
+          - "5.28"
+          - "5.26"
+          - "5.24"
+          - "5.22"
+          - "5.20"
+
+    container:
+      image: perldocker/perl-tester:${{ matrix.perl-version }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: cpanm --notest Dist::Zilla
+      - run: dzil authordeps --missing | cpanm
+      - run: dzil listdeps --author --missing | cpanm
+      - run: dzil test --author --release


### PR DESCRIPTION
I know that the only test at the current tip of master is just a no-op, however if #19 is ever merged, this will provide the infrastructure to run CI jobs on GitHub and to test future contributions.